### PR TITLE
build: Disable configuration cache

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,3 @@ exposedVersion=0.44.1
 flexmarkVersion=0.64.8
 kotestVersion = 5.8.0
 
-# Gradle configuration cache:
-# https://docs.gradle.org/current/userguide/configuration_cache.html
-org.gradle.configuration-cache=true


### PR DESCRIPTION
It is causing a few issues, and not bringing a lot of value for the CI
since it is not cached by Gradle GitHub Action.
