### PR TITLE
ci: Avoid creating multiple duplicated releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,6 +156,9 @@ jobs:
   create-release:
     name: Creates a GitHub Release
     runs-on: ubuntu-latest
+    concurrency:
+      group: "create-releases"
+      cancel-in-progress: true
     needs:
       - check-if-prod
       - build-docker


### PR DESCRIPTION
For example, these two are basically the same:

- https://github.com/Liber-UFPE/visaoholandesa/releases/tag/v9-af6a834
- https://github.com/Liber-UFPE/visaoholandesa/releases/tag/v8-c4b224f


