### PR TITLE
refactors: Move executable classes to task package and add a few tests

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,1 @@
-export GRADLE_OPTS="-Dorg.gradle.console=verbose"
+export GRADLE_OPTS="-Dorg.gradle.console=verbose -Dsonar.gradle.skipCompile=true"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -137,6 +137,13 @@ sonar {
                         .filter(File::exists)
                 },
         )
+
+        // See docs here:
+        // https://docs.sonarsource.com/sonarqube/latest/project-administration/analysis-scope/#code-coverage-exclusion
+        property(
+            "sonar.coverage.exclusions",
+            listOf("**/*Generated*", "**/tasks/*.*"),
+        )
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -106,37 +106,9 @@ sonar {
         // https://docs.sonarsource.com/sonarcloud/advanced-setup/languages/kotlin/#specifying-the-kotlin-source-code-version
         property("sonar.kotlin.source.version", "1.9")
 
-        property(
-            "sonar.sources",
-            sourceSets
-                .main
-                .get()
-                .allSource
-                .srcDirs
-                .filterNot {
-                    // Exclude generated files
-                    it.absolutePath.startsWith(layout.buildDirectory.asFile.get().absolutePath)
-                }
-                .filter(File::exists),
-        )
-
-        property(
-            "sonar.tests",
-            sourceSets
-                // Include any source set that contains test in its name.
-                // For example, "test", "integrationTest", etc.
-                .filter { sourceSet -> sourceSet.name.contains("test", ignoreCase = true) }
-                .flatMap { sourceSet ->
-                    sourceSet
-                        .allSource
-                        .srcDirs
-                        .filterNot { dir ->
-                            // Exclude generated files
-                            dir.absolutePath.startsWith(layout.buildDirectory.asFile.get().absolutePath)
-                        }
-                        .filter(File::exists)
-                },
-        )
+        property("sonar.sources", "src/main")
+        property("sonar.tests", listOf("src/test", "src/accessibilityTest"))
+        property("sonar.exclusions", listOf("src/main/resources/**/*.sql", "src/main/resources/**/*.xml"))
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -208,7 +208,7 @@ val accessibilityTestImplementation: Configuration = configurations["accessibili
 koverReport {
     filters {
         excludes {
-            classes("br.ufpe.liber.model.Database*", "br.ufpe.liber.Sitemaps")
+            classes("br.ufpe.liber.tasks.*")
         }
     }
 }
@@ -425,7 +425,7 @@ tasks.register<JavaExec>("generateSitemaps") {
     group = "Application"
     description = "Generate Sitemap.xml"
     classpath = sourceSets.main.get().runtimeClasspath
-    mainClass = "br.ufpe.liber.Sitemaps"
+    mainClass = "br.ufpe.liber.tasks.Sitemaps"
 }
 
 // Install pre-commit git hooks to run ktlint and detekt

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -180,7 +180,7 @@ val accessibilityTestImplementation: Configuration = configurations["accessibili
 koverReport {
     filters {
         excludes {
-            classes("br.ufpe.liber.tasks.*")
+            classes("br.ufpe.liber.tasks.*", "br.ufpe.liber.*.*Generated")
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -106,9 +106,37 @@ sonar {
         // https://docs.sonarsource.com/sonarcloud/advanced-setup/languages/kotlin/#specifying-the-kotlin-source-code-version
         property("sonar.kotlin.source.version", "1.9")
 
-        property("sonar.sources", "src/main")
-        property("sonar.tests", listOf("src/test", "src/accessibilityTest"))
-        property("sonar.exclusions", listOf("src/main/resources/**/*.sql", "src/main/resources/**/*.xml"))
+        property(
+            "sonar.sources",
+            sourceSets
+                .main
+                .get()
+                .allSource
+                .srcDirs
+                .filterNot {
+                    // Exclude generated files
+                    it.absolutePath.startsWith(layout.buildDirectory.asFile.get().absolutePath)
+                }
+                .filter(File::exists),
+        )
+
+        property(
+            "sonar.tests",
+            sourceSets
+                // Include any source set that contains test in its name.
+                // For example, "test", "integrationTest", etc.
+                .filter { sourceSet -> sourceSet.name.contains("test", ignoreCase = true) }
+                .flatMap { sourceSet ->
+                    sourceSet
+                        .allSource
+                        .srcDirs
+                        .filterNot { dir ->
+                            // Exclude generated files
+                            dir.absolutePath.startsWith(layout.buildDirectory.asFile.get().absolutePath)
+                        }
+                        .filter(File::exists)
+                },
+        )
     }
 }
 

--- a/src/main/kotlin/br/ufpe/liber/controllers/AssetsController.kt
+++ b/src/main/kotlin/br/ufpe/liber/controllers/AssetsController.kt
@@ -34,17 +34,24 @@ class AssetsController(
         return assetsResolver
             .fromHashed("/$path")
             .flatMap { asset ->
-                asset.preferredEncodedResource(encoding).flatMap { availableEncoding ->
-                    resourceResolver.getResourceAsStream(asset.classpath(availableEncoding.extension))
-                        .map { inputStream ->
-                            HttpResponse.ok(StreamedFile(inputStream, asset.mediaType()))
-                                .contentEncoding(availableEncoding.http)
-                        }
-                }.or {
-                    resourceResolver.getResourceAsStream(asset.classpath()).map { inputStream ->
-                        HttpResponse.ok(StreamedFile(inputStream, asset.mediaType()))
+                asset
+                    .preferredEncodedResource(encoding)
+                    .flatMap { availableEncoding ->
+                        resourceResolver
+                            .getResourceAsStream(asset.classpath(availableEncoding.extension))
+                            .map { inputStream ->
+                                HttpResponse
+                                    .ok(StreamedFile(inputStream, asset.mediaType()))
+                                    .contentEncoding(availableEncoding.http)
+                            }
                     }
-                }
+                    .or {
+                        resourceResolver
+                            .getResourceAsStream(asset.classpath())
+                            .map { inputStream ->
+                                HttpResponse.ok(StreamedFile(inputStream, asset.mediaType()))
+                            }
+                    }
             }
             .map { response ->
                 response

--- a/src/main/kotlin/br/ufpe/liber/tasks/DatabaseBooks.kt
+++ b/src/main/kotlin/br/ufpe/liber/tasks/DatabaseBooks.kt
@@ -1,5 +1,7 @@
-package br.ufpe.liber.model
+package br.ufpe.liber.tasks
 
+import br.ufpe.liber.model.Book
+import br.ufpe.liber.model.Page
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.jetbrains.exposed.dao.LongEntity

--- a/src/main/kotlin/br/ufpe/liber/tasks/Sitemaps.kt
+++ b/src/main/kotlin/br/ufpe/liber/tasks/Sitemaps.kt
@@ -1,5 +1,6 @@
-package br.ufpe.liber
+package br.ufpe.liber.tasks
 
+import br.ufpe.liber.Templates
 import br.ufpe.liber.model.BookRepository
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.env.Environment

--- a/src/test/kotlin/br/ufpe/liber/controllers/AssetsControllerTest.kt
+++ b/src/test/kotlin/br/ufpe/liber/controllers/AssetsControllerTest.kt
@@ -1,6 +1,67 @@
 package br.ufpe.liber.controllers
 
+import br.ufpe.liber.assets.AssetsResolver
 import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.data.forAll
+import io.kotest.data.row
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldStartWith
+import io.micronaut.core.io.ResourceResolver
+import io.micronaut.http.HttpHeaders.CACHE_CONTROL
+import io.micronaut.http.HttpHeaders.CONTENT_ENCODING
+import io.micronaut.http.HttpStatus
+import io.mockk.every
+import io.mockk.mockk
+import java.io.File
+import java.util.Optional
 
 class AssetsControllerTest : BehaviorSpec({
+    given("#asset") {
+        val resourceResolver: ResourceResolver = mockk()
+        every { resourceResolver.getResourceAsStream("classpath:public/assets-metadata.json") } answers {
+            Optional.of(File("src/test/resources/public/assets-metadata.json").inputStream())
+        }
+
+        // mock assets and its encoded versions (br, gzip, etc.)
+        listOf("javascripts/main.34UGRNNI.js", "stylesheets/main.Y6PST7YS.css").flatMap {
+            listOf("public/$it", "public/$it.br", "public/$it.gz", "public/$it.zz")
+        }.forEach { mockedAsset ->
+            every { resourceResolver.getResourceAsStream("classpath:$mockedAsset") } answers {
+                Optional.of("some content".byteInputStream())
+            }
+        }
+
+        val assetsResolver = AssetsResolver(resourceResolver)
+        val assetsController = AssetsController(assetsResolver, resourceResolver)
+
+        then("return HTTP Not Found if asset does not exist") {
+            assetsController.asset("br, gzip", "asset/not-there.js").status() shouldBe HttpStatus.NOT_FOUND
+        }
+
+        forAll(
+            row("javascripts/main.34UGRNNI.js", "br, gzip, deflate", HttpStatus.OK, Optional.of("br")),
+            row("javascripts/main.34UGRNNI.js", "gzip, deflate", HttpStatus.OK, Optional.of("gzip")),
+            row("javascripts/main.34UGRNNI.js", "deflate", HttpStatus.OK, Optional.of("deflate")),
+            row("javascripts/main.34UGRNNI.js", "", HttpStatus.OK, Optional.empty<String>()),
+            row("stylesheets/main.Y6PST7YS.css", "br, gzip, deflate", HttpStatus.OK, Optional.of("br")),
+        ) { requested, acceptEncoding, expectedStatus, expectedEncoding ->
+            `when`("requesting $requested with Accept-Encoding $acceptEncoding") {
+                then("should return HTTP $expectedStatus") {
+                    assetsController.asset(acceptEncoding, requested).status() shouldBe expectedStatus
+                }
+
+                then("should return the encoded version $expectedEncoding") {
+                    val response = assetsController.asset(acceptEncoding, requested)
+                    Optional.ofNullable(response.header(CONTENT_ENCODING)) shouldBe expectedEncoding
+                }
+
+                then("should set Cache-Control header") {
+                    val response = assetsController.asset(acceptEncoding, requested)
+                    response.header(CACHE_CONTROL) shouldStartWith "public, max-age="
+                    response.header(CACHE_CONTROL) shouldContain "immutable"
+                }
+            }
+        }
+    }
 })


### PR DESCRIPTION
- refactor: move executable classes to tasks package
- sonar: simplify source configuration
- sonar: skip compilation locally
- build: ignore generated code in code coverage
- tests: Add more tests for AssetsResolver
- tests: Add tests for AssetsController
