### PR TITLE
assets: Some refactorings

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -539,4 +539,5 @@ dependencies {
     assetsImplementation("org.lz4:lz4-pure-java:1.8.0")
     assetsImplementation("org.apache.tika:tika-core:2.9.1")
     assetsImplementation("org.apache.tika:tika-parsers-standard-package:2.9.1")
+    assetsImplementation("org.apache.logging.log4j:log4j-core:2.22.1")
 }

--- a/src/main/jte/layout.kte
+++ b/src/main/jte/layout.kte
@@ -2,6 +2,7 @@
 @import br.ufpe.liber.views.LinksHelper
 @import br.ufpe.liber.views.LinksHelper.linkTo
 @import br.ufpe.liber.views.ViewsHelper.notHtmxRequest
+@import br.ufpe.liber.assets.AssetsViewHelpers.at
 
 @param title: String
 @param content: gg.jte.Content
@@ -18,7 +19,16 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="google-site-verification" content="lAucrunLv2Pcy2awf5Zlo1DtQmEk2X3Dwyo57E-sorw" />
         <link rel="preconnect" href="https://unpkg.com/" />
-        <link rel="icon" type="image/x-icon" href="${linkTo("/public/images/favicon.ico")}" />
+
+        !{val faviconAssetOpt = at("/images/favicon.ico")}
+        @if(faviconAssetOpt.isPresent)
+            !{val faviconAsset = faviconAssetOpt.get()}
+            <link href="${linkTo(faviconAsset.fullpath("/static"))}"
+                  rel="icon"
+                  type="image/x-icon"
+                  integrity="${faviconAsset.integrity}"
+                  crossorigin="anonymous" />
+        @endif
 
         @template.assets.stylesheet(path = "/stylesheets/main.css", prefix = "/static")
     @endif
@@ -96,8 +106,8 @@
 
 <%-- Only renders the `footer` section if NOT a htmx request (first page load, for example) --%>
 @if(notHtmxRequest())
-<footer id="footer" class="bg-dark">
-    <div class="bg-dark container">
+<footer id="footer" class="position-relative overflow-hidden bg-dark">
+    <div class="container">
         <div class="row row-cols-1 row-cols-sm-2 row-cols-md-5 py-5">
             <div class="col mb-3">
                 <a href="${LinksHelper.Liber.SITE}" class="d-flex align-items-center mb-3 link-body-emphasis text-decoration-none">

--- a/src/main/kotlin/br/ufpe/liber/assets/Assets.kt
+++ b/src/main/kotlin/br/ufpe/liber/assets/Assets.kt
@@ -25,10 +25,8 @@ class AssetsResolver(resourceResolver: ResourceResolver) {
     init {
         resourceResolver.getResourceAsStream("classpath:public/assets-metadata.json").ifPresent { inputStream ->
             val json = inputStream.bufferedReader().use(BufferedReader::readText)
-            val fromJson: Map<String, Asset> = Json.decodeFromString(json)
-            assets.putAll(fromJson)
-
-            fromJson.forEach { (_, asset) ->
+            Json.decodeFromString<List<Asset>>(json).forEach { asset: Asset ->
+                assets[asset.source] = asset
                 assetsWithHashedVersionAsKeys[asset.filename] = asset
             }
         }

--- a/src/main/kotlin/br/ufpe/liber/tasks/GenerateAssetsMetadata.kt
+++ b/src/main/kotlin/br/ufpe/liber/tasks/GenerateAssetsMetadata.kt
@@ -43,7 +43,7 @@ object GenerateAssetsMetadata {
         val assetsParentDir = File(args.first())
         val metafile = File(assetsParentDir, "assets-metadata.json")
 
-        val metadata: MutableMap<String, Asset> = mutableMapOf()
+        val metadata: MutableList<Asset> = mutableListOf()
         val regex = "(?<filename>[A-Za-z/-]+).(?<hash>[A-Z0-9]{8}).(?<extension>[a-z]+)".toPattern()
 
         val digest = DigestUtils.getSha384Digest()
@@ -70,15 +70,17 @@ object GenerateAssetsMetadata {
 
                     val source = "$basename.$extension"
 
-                    metadata[source] = Asset(
-                        basename,
-                        source,
-                        assetPath,
-                        hash,
-                        integrity,
-                        extension,
-                        mediaType.toString(),
-                        findEncodings(file).sorted(),
+                    metadata.add(
+                        Asset(
+                            basename,
+                            source,
+                            assetPath,
+                            hash,
+                            integrity,
+                            extension,
+                            mediaType.toString(),
+                            findEncodings(file).sorted(),
+                        ),
                     )
                 }
             }

--- a/src/test/resources/public/assets-metadata.json
+++ b/src/test/resources/public/assets-metadata.json
@@ -1,5 +1,5 @@
-{
-  "/javascripts/main.js": {
+[
+  {
     "basename": "/javascripts/main",
     "source": "/javascripts/main.js",
     "filename": "/javascripts/main.34UGRNNI.js",
@@ -25,7 +25,7 @@
       }
     ]
   },
-  "/stylesheets/main.css": {
+  {
     "basename": "/stylesheets/main",
     "source": "/stylesheets/main.css",
     "filename": "/stylesheets/main.Y6PST7YS.css",
@@ -51,4 +51,4 @@
       }
     ]
   }
-}
+]


### PR DESCRIPTION
- assets: Use esbuild plugins instead of promises chaining
- assets: assets metadata as a list instead of map
- assets: Add dependency to avoid logging warning
- assets: use optimized version for favicon asset
